### PR TITLE
Add EchoSight services pricing table

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,45 @@
+/* Custom styles for pricing table */
+.pricing-table-container {
+  overflow-x: auto;
+}
+
+.pricing-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pricing-table th,
+.pricing-table td {
+  padding: 0.75em;
+  border-bottom: 1px solid #ddd;
+}
+
+.pricing-table th {
+  background-color: #e8f7f6;
+  color: #222;
+  text-align: left;
+}
+
+.pricing-table tbody tr:nth-child(odd) {
+  background-color: #f9f9f9;
+}
+
+@media (max-width: 700px) {
+  .pricing-table th,
+  .pricing-table td {
+    white-space: nowrap;
+  }
+}
+
+/* Visually hidden but accessible */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/services.html
+++ b/services.html
@@ -5,6 +5,7 @@
   <title>Services | Echosight</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/custom.css">
 </head>
 
   <style>
@@ -195,6 +196,68 @@
 </div>
 
 <div class="container" style="max-width:950px;margin:2em auto 2em auto;">
+
+  <div class="section">
+    <h2>EchoSight Field &amp; Analysis Services</h2>
+    <div class="pricing-table-container">
+      <table class="pricing-table">
+        <caption class="sr-only">EchoSight Field &amp; Analysis Services</caption>
+        <thead>
+          <tr>
+            <th scope="col">Package/Service</th>
+            <th scope="col">What's Included</th>
+            <th scope="col">Key Deliverables</th>
+            <th scope="col">Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Dusk Emergence Survey</td>
+            <td>
+              <ul>
+                <li>Thermal imaging</li>
+                <li>Full-spectrum acoustic logging</li>
+                <li>Automated video analysis</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Survey summary report</li>
+                <li>Emergence maps &amp; figures</li>
+                <li>Species list</li>
+              </ul>
+            </td>
+            <td>£395*</td>
+          </tr>
+          <tr>
+            <td>Additional visit/repeat survey</td>
+            <td>Repeat field survey at the same site</td>
+            <td>Updated emergence data summary</td>
+            <td>£295</td>
+          </tr>
+          <tr>
+            <td>Custom AI video analysis</td>
+            <td>Motion Tracker applied to your footage</td>
+            <td>Activity report &amp; timestamps</td>
+            <td>Enquire</td>
+          </tr>
+          <tr>
+            <td>Specialist data review/reporting</td>
+            <td>Review of existing survey data</td>
+            <td>Written assessment &amp; advice</td>
+            <td>Enquire</td>
+          </tr>
+          <tr>
+            <td>Other protected species support</td>
+            <td>Camera trapping, static detection &amp; more</td>
+            <td>Tailored deliverables</td>
+            <td>Enquire</td>
+          </tr>
+        </tbody>
+      </table>
+      <p style="font-size:0.9em;">*Within 60 miles of Newbury. Additional mileage at £0.45/mile.</p>
+    </div>
+  </div>
 
   <div class="section" style="background:#e8f7f6;border-radius:12px;padding:2em;margin:2em 0;">
     <h2 style="margin-top:0;">Dusk Emergence Survey Package</h2>


### PR DESCRIPTION
## Summary
- add responsive pricing table CSS
- insert pricing table for EchoSight Field & Analysis Services
- link new stylesheet in services.html

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873e43ded94832598b3233284904c11