### PR TITLE
Improve landing page semantics and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,6 +9,7 @@
 </head>
 <!-- NAVIGATION (BURGER MENU) -->
 <!-- NAVIGATION (BURGER MENU WITH LOGO) -->
+<header>
 <nav class="nav-bar">
   <div class="nav-content">
     <span class="logo-area">
@@ -22,18 +23,19 @@
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>
     </div>
-    <div class="burger" id="burgerBtn" aria-label="Open menu" tabindex="0">
+    <button class="burger" id="burgerBtn" aria-label="Open menu">
       <span></span><span></span><span></span>
-    </div>
+    </button>
   </div>
 </nav>
+</header>
 
 
 
 <!-- About/Trust Section (Contained) -->
-<div class="container section" style="background:#fff;border-radius:12px;padding:2em;margin:2em auto;box-shadow:0 4px 16px rgba(0,0,0,0.1);">
+<div class="container section about-box">
   <div class="about-row">
-    <img src="assets/images/jack-headshot.jpg" class="about-img" alt="Jack Curry">
+    <img src="images/header.jpg" class="about-img" alt="Jack Curry">
     <div>
       <h2>Meet Jack Curry</h2>
       <p>
@@ -53,7 +55,7 @@
 </div>
 
 
-<footer style="text-align:center;padding:1em 0;color:#aaa;">
+<footer class="site-footer">
   &copy; 2025 Echosight by Jack Curry. | <a href="https://www.instagram.com/echosight.uk/" target="_blank">Instagram</a> | <a href="contact.html">Contact</a>
   <script src="assets/js/nav.js"></script>
 </footer>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -265,3 +265,108 @@ body {
     font-size: 1.12em;
   }
 }
+/* Utility classes extracted from inline styles */
+.feature-box {
+  background: #e8f7f6;
+  border-radius: 14px;
+  padding: 2.2em 1.2em 2.8em 1.2em;
+  margin: 2em auto;
+  box-shadow: 0 6px 32px rgba(57,197,187,0.09), 0 1.5px 12px rgba(0,0,0,0.07);
+}
+.intro-center {
+  text-align: center;
+  max-width: 700px;
+  margin: 0 auto 2.5em;
+}
+.media-frame {
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.13);
+}
+.section-note {
+  margin-top: 1em;
+  font-style: italic;
+}
+.price-tag {
+  font-size: 2em;
+  font-weight: bold;
+  color: #222;
+  margin: 1em 0 0.5em;
+}
+.site-footer {
+  text-align: center;
+  padding: 1em 0;
+  color: #aaa;
+}
+.about-box {
+  background: #fff;
+  border-radius: 12px;
+  padding: 2em;
+  margin: 2em auto;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+}
+.contact-box {
+  max-width: 600px;
+  margin: 2em auto;
+  background: #fff;
+  padding: 2em;
+  border-radius: 10px;
+  box-shadow: 0 2px 14px rgba(30,30,45,0.08);
+}
+.form-flex {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+.input-field {
+  padding: 0.7em;
+  border-radius: 5px;
+  border: 1px solid #bbb;
+}
+.btn-narrow {
+  width: 150px;
+}
+.mt-2 {
+  margin-top: 2em;
+}
+.mt-1 {
+  margin-top: 1em;
+}
+.services-container {
+  max-width: 950px;
+  margin: 2em auto;
+}
+.section-highlight {
+  background: #e8f7f6;
+  border-radius: 12px;
+  padding: 2em;
+  margin: 2em 0;
+}
+.no-top-margin {
+  margin-top: 0;
+}
+.flex-media {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5em;
+}
+.media-rounded {
+  border-radius: 8px;
+}
+.section-gap {
+  margin-bottom: 2em;
+}
+.resources-box {
+  max-width: 700px;
+  margin: 2em auto;
+  background: #fff;
+  padding: 2em;
+  border-radius: 10px;
+  box-shadow: 0 2px 14px rgba(30,30,45,0.08);
+}
+.stacked-list {
+  line-height: 1.6;
+}
+.nav-bar .burger {
+  border: none;
+  background: transparent;
+}

--- a/contact.html
+++ b/contact.html
@@ -10,6 +10,7 @@
 <body>
 
     <!-- NAVIGATION (BURGER MENU WITH LOGO) -->
+<header>
 <nav class="nav-bar">
   <div class="nav-content">
     <span class="logo-area">
@@ -23,34 +24,35 @@
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>
     </div>
-    <div class="burger" id="burgerBtn" aria-label="Open menu" tabindex="0">
+    <button class="burger" id="burgerBtn" aria-label="Open menu">
       <span></span><span></span><span></span>
-    </div>
+    </button>
   </div>
 </nav>
+</header>
 
-<div class="container" style="max-width:600px;margin:2em auto 2em auto;background:#fff;padding:2em;border-radius:10px;box-shadow:0 2px 14px rgba(30,30,45,0.08);">
+<div class="container contact-box">
   <h1>Contact Me</h1>
   <p>
-    Interested in working together, booking a survey, or requesting a sample report? Get in touch below or email <b>jack.curry@echosight.co.uk</b> directly.
+    Interested in working together, booking a survey, or requesting a sample report? Get in touch below or email <strong>jack.curry@echosight.co.uk</strong> directly.
   </p>
-  <form method="post" action="mailto:jack.curry@echosight.co.uk" enctype="text/plain" style="display:flex;flex-direction:column;gap:1em;">
+  <form method="post" action="mailto:jack.curry@echosight.co.uk" enctype="text/plain" class="form-flex">
     <label for="name">Your Name:</label>
-    <input type="text" name="name" id="name" required style="padding:0.7em; border-radius:5px; border:1px solid #bbb;">
+    <input type="text" name="name" id="name" required class="input-field">
     <label for="email">Your Email:</label>
-    <input type="email" name="email" id="email" required style="padding:0.7em; border-radius:5px; border:1px solid #bbb;">
+    <input type="email" name="email" id="email" required class="input-field">
     <label for="message">Message:</label>
-    <textarea name="message" id="message" rows="6" required style="padding:0.7em; border-radius:5px; border:1px solid #bbb;"></textarea>
-    <button type="submit" class="cta-btn" style="width:150px;">Send</button>
+    <textarea name="message" id="message" rows="6" required class="input-field"></textarea>
+    <button type="submit" class="cta-btn btn-narrow">Send</button>
   </form>
-  <div style="margin-top:2em;">
-    <b>Echosight</b><br>
+  <div class="mt-2">
+    <strong>Echosight</strong><br>
     Newbury, Berkshire<br>
     <a href="mailto:jack.curry@echosight.co.uk">jack.curry@echosight.co.uk</a><br>
     <a href="https://www.instagram.com/echosight.uk/" target="_blank">Instagram</a>
   </div>
 </div>
-<footer style="text-align:center;padding:1em 0;color:#aaa;">
+<footer class="site-footer">
   &copy; 2025 Echosight by Jack Curry.
   <script src="assets/js/nav.js"></script>
 </footer>

--- a/index.html
+++ b/index.html
@@ -6,10 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="assets/css/main.css">
   <link rel="stylesheet" href="assets/css/custom.css">
+  <meta name="description" content="Specialist bat survey support with thermal imaging and acoustic analysis." />
   </head>
 <body>
 
 <!-- NAVIGATION (BURGER MENU WITH LOGO) -->
+<header>
 <nav class="nav-bar">
   <div class="nav-content">
     <span class="logo-area">
@@ -23,14 +25,17 @@
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>
     </div>
-    <div class="burger" id="burgerBtn" aria-label="Open menu" tabindex="0">
+    <button class="burger" id="burgerBtn" aria-label="Open menu">
       <span></span><span></span><span></span>
-    </div>
+    </button>
   </div>
 </nav>
+</header>
+
+<main>
 
 <!-- Hero Section -->
-<div class="hero-video">
+<section class="hero-video">
   <video autoplay muted loop playsinline>
     <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
   </video>
@@ -43,14 +48,14 @@
     </p>
     <a href="contact.html" class="cta-btn">Request a Quote</a>
   </div>
-</div>
+</section>
 
 <!-- Feature Cards Section (Contained) -->
-<div class="container" style="background:#e8f7f6;border-radius:14px;padding:2.2em 1.2em 2.8em 1.2em;margin:2em auto 2em auto;box-shadow:0 6px 32px rgba(57,197,187,0.09),0 1.5px 12px rgba(0,0,0,0.07);">
-  <p style="text-align:center;max-width:700px;margin:0 auto 2.5em;">
-    <b>
+<section class="container feature-box">
+  <p class="intro-center">
+    <strong>
       Echosight provides specialist bat survey support for ecology consultancies—offering a comprehensive review service that combines expert fieldwork and human analysis with the latest technology. Every dataset is double-checked to ensure no bats are missed. All surveys use my own high-spec equipment and bespoke tools. Flexible and reliable support, whenever you need it.
-    </b>
+    </strong>
   </p>
   <div class="feature-cards">
     <div class="feature-card">
@@ -75,47 +80,47 @@
       <a href="services.html#reporting">Learn more about reporting &rarr;</a>
     </div>
   </div>
-</div>
+</section>
 
 <!-- See the Difference (Contained) -->
-<div class="container">
+<section class="container">
   <h2>See the Difference</h2>
   <div class="see-diff-cards">
     <div>
-      <video controls width="100%" style="border-radius:10px;box-shadow:0 4px 16px rgba(0,0,0,0.13);">
-        <source src="assets/videos/emergence-thermal-example.mp4" type="video/mp4">
+      <video controls width="100%" class="media-frame">
+        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
       </video>
     </div>
     <div>
-      <video controls width="100%" style="border-radius:10px;box-shadow:0 4px 16px rgba(0,0,0,0.13);">
-        <source src="assets/videos/motion-tracker-demo.mp4" type="video/mp4">
+      <video controls width="100%" class="media-frame">
+        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
       </video>
     </div>
     <div>
-      <img src="assets/images/acoustic-analysis.jpg" alt="Acoustic Analysis Screenshot" style="border-radius:10px;box-shadow:0 4px 16px rgba(0,0,0,0.13);width:100%;">
+      <img src="images/header.jpg" alt="Acoustic Analysis Screenshot" class="media-frame" width="100%">
     </div>
   </div>
-  <p style="margin-top:1em;font-style:italic;">All bat survey footage and analyses are generated in-house using Echosight’s own equipment and AI workflow.</p>
-</div>
+  <p class="section-note">All bat survey footage and analyses are generated in-house using Echosight’s own equipment and AI workflow.</p>
+</section>
 
 <!-- Pricing/Packages (Contained) -->
-<div class="container pricing">
+<section class="container pricing">
   <h2>Transparent Pricing</h2>
-  <p><b>Typical Dusk Emergence Package</b></p>
+  <p><strong>Typical Dusk Emergence Package</strong></p>
   <ul>
     <li>Thermal, acoustic, and video survey (within 60 miles of Newbury)</li>
     <li>AI-powered emergence and activity analysis</li>
     <li>Consultant-ready report with timestamped figures & species interpretation</li>
     <li>Email/phone follow-up support</li>
   </ul>
-  <div style="font-size:2em;font-weight:bold; color:#222; margin:1em 0 0.5em;">£395</div>
+  <div class="price-tag">£395</div>
   <div>Fixed price. No hidden fees.</div>
-</div>
+</section>
 
 <!-- About/Trust Section (Contained) -->
-<div class="container">
+<section class="container">
   <div class="about-row">
-    <img src="assets/images/jack-headshot.jpg" class="about-img" alt="Jack Curry">
+    <img src="images/header.jpg" class="about-img" alt="Jack Curry">
     <div>
       <h2>Meet Jack Curry</h2>
       <p>
@@ -126,10 +131,10 @@
       <p><a href="about.html">More about Jack & Echosight &raquo;</a></p>
     </div>
   </div>
-</div>
+</section>
 
 <!-- Why Choose Echosight/Testimonials (Contained) -->
-<div class="container">
+<section class="container">
   <h2>Why Choose Echosight?</h2>
   <ul>
     <li>Consultancy support, not competition—no direct-to-end-client work</li>
@@ -139,20 +144,21 @@
   </ul>
   <!-- Placeholder testimonial -->
   <div class="testimonial">
-    <b>“The quality of data and reporting from Echosight saved us hours on every project. Jack’s technology is a game changer for bat survey delivery.”</b>
+    <strong>“The quality of data and reporting from Echosight saved us hours on every project. Jack’s technology is a game changer for bat survey delivery.”</strong>
     <br>– Senior Ecologist, [Consultancy Name]
   </div>
-</div>
+</section>
 
 <!-- Contact/Booking Section (Contained) -->
-<div class="container">
+<section class="container">
   <h2>Ready to Book?</h2>
   <p>Click below to get in touch, check availability, or request a sample report.</p>
   <a href="contact.html" class="cta-btn">Contact Me</a>
-</div>
+</section>
+</main>
 
 <!-- Footer -->
-<footer style="text-align:center;padding:1em 0;color:#aaa;">
+<footer class="site-footer">
   &copy; 2025 Echosight by Jack Curry. | <a href="https://www.instagram.com/echosight.uk/" target="_blank">Instagram</a> | <a href="contact.html">Contact</a>
 </footer>
   <script src="assets/js/nav.js"></script>

--- a/resources.html
+++ b/resources.html
@@ -9,6 +9,7 @@
 </head>
 <!-- NAVIGATION (BURGER MENU) -->
 <!-- NAVIGATION (BURGER MENU WITH LOGO) -->
+<header>
 <nav class="nav-bar">
   <div class="nav-content">
     <span class="logo-area">
@@ -22,26 +23,27 @@
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>
     </div>
-    <div class="burger" id="burgerBtn" aria-label="Open menu" tabindex="0">
+    <button class="burger" id="burgerBtn" aria-label="Open menu">
       <span></span><span></span><span></span>
-    </div>
+    </button>
   </div>
 </nav>
+</header>
 
 
 
 <!-- Resources Section -->
-<div class="container" style="max-width:700px;margin:2em auto;background:#fff;padding:2em;border-radius:10px;box-shadow:0 2px 14px rgba(30,30,45,0.08);">
+<div class="container resources-box">
   <h1>Resources</h1>
   <p>Useful documents and links from Echosight.</p>
-  <ul style="line-height:1.6;">
+  <ul class="stacked-list">
     <li><a href="assets/Jack-Curry-MSc-BSc-CV.pdf" target="_blank">Download Jack Curry's CV (PDF)</a></li>
     <li><a href="contact.html">Request a Sample Report</a></li>
   </ul>
 </div>
 
 
-<footer style="text-align:center;padding:1em 0;color:#aaa;">
+<footer class="site-footer">
   &copy; 2025 Echosight by Jack Curry. | <a href="https://www.instagram.com/echosight.uk/" target="_blank">Instagram</a> | <a href="contact.html">Contact</a>
   <script src="assets/js/nav.js"></script>
 </footer>

--- a/services.html
+++ b/services.html
@@ -12,6 +12,7 @@
 
 <body>
 <!-- NAVIGATION (BURGER MENU WITH LOGO) -->
+<header>
 <nav class="nav-bar">
   <div class="nav-content">
     <span class="logo-area">
@@ -25,11 +26,12 @@
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>
     </div>
-    <div class="burger" id="burgerBtn" aria-label="Open menu" tabindex="0">
+    <button class="burger" id="burgerBtn" aria-label="Open menu">
       <span></span><span></span><span></span>
-    </div>
+    </button>
   </div>
 </nav>
+</header>
 
 <!-- Hero Section -->
 <div class="hero-video">
@@ -46,47 +48,47 @@
   </div>
 </div>
 
-<div class="container" style="max-width:950px;margin:2em auto 2em auto;">
+<div class="container services-container">
 
-  <div class="section" style="background:#e8f7f6;border-radius:12px;padding:2em;margin:2em 0;">
-    <h2 style="margin-top:0;">Dusk Emergence Survey Package</h2>
+  <div class="section section-highlight">
+    <h2 class="no-top-margin">Dusk Emergence Survey Package</h2>
     <ul>
-      <li>Professional <b>thermal imaging</b> with Pixfra ARC LRF A625 Pro</li>
-      <li><b>Full-spectrum acoustic monitoring</b> (BatLogger M2)</li>
-      <li>Automated video analysis using in-house <b>Echosight Motion Tracker</b></li>
+      <li>Professional <strong>thermal imaging</strong> with Pixfra ARC LRF A625 Pro</li>
+      <li><strong>Full-spectrum acoustic monitoring</strong> (BatLogger M2)</li>
+      <li>Automated video analysis using in-house <strong>Echosight Motion Tracker</strong></li>
       <li>Real-time and post-survey data review for emergence confirmation</li>
-      <li><b>Consultant-ready report:</b> timestamped figures, mapped emergence events, species list, site recommendations</li>
+      <li><strong>Consultant-ready report:</strong> timestamped figures, mapped emergence events, species list, site recommendations</li>
       <li>Follow-up Q&A and data support</li>
     </ul>
-    <div style="font-size:1.5em;font-weight:bold;color:#222;margin-top:1em;">£395</div>
+    <div class="price-tag">£395</div>
     <div>Within 60 miles of Newbury. Additional mileage at £0.45/mile.</div>
   </div>
   <div class="section">
     <h2>Additional Services</h2>
     <ul>
-      <li>Additional visit/repeat survey: <b>£295</b></li>
-      <li>Custom AI video analysis of third-party footage: <b>Enquire</b></li>
-      <li>Specialist data review or reporting: <b>Enquire</b></li>
-      <li>Other protected species survey support: <b>Enquire</b></li>
+      <li>Additional visit/repeat survey: <strong>£295</strong></li>
+      <li>Custom AI video analysis of third-party footage: <strong>Enquire</strong></li>
+      <li>Specialist data review or reporting: <strong>Enquire</strong></li>
+      <li>Other protected species survey support: <strong>Enquire</strong></li>
     </ul>
   </div>
-  <div class="section" style="margin-bottom:2em;">
+  <div class="section section-gap">
     <h2>Sample Footage & Reports</h2>
-    <div style="display:flex;flex-wrap:wrap;gap:1.5em;">
-      <video controls width="340" style="border-radius:8px;">
-        <source src="assets/videos/emergence-thermal-example.mp4" type="video/mp4">
+    <div class="flex-media">
+      <video controls width="340" class="media-rounded">
+        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
         Your browser does not support the video tag.
       </video>
-      <video controls width="340" style="border-radius:8px;">
-        <source src="assets/videos/motion-tracker-demo.mp4" type="video/mp4">
+      <video controls width="340" class="media-rounded">
+        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
         Your browser does not support the video tag.
       </video>
-      <img src="assets/images/sample-report-placeholder.jpg" alt="Sample Report" style="width:340px; border-radius:8px;">
+      <img src="images/header.jpg" alt="Sample Report" width="340" class="media-rounded">
     </div>
-    <p style="margin-top:1em;">Interested in a full sample report? <a href="contact.html">Request one here.</a></p>
+    <p class="mt-1">Interested in a full sample report? <a href="contact.html">Request one here.</a></p>
   </div>
 </div>
-<footer style="text-align:center;padding:1em 0;color:#aaa;">
+<footer class="site-footer">
   &copy; 2025 Echosight by Jack Curry. | <a href="https://www.instagram.com/echosight.uk/" target="_blank">Instagram</a> | <a href="contact.html">Contact</a>
   <script src="assets/js/nav.js"></script>
 </footer>


### PR DESCRIPTION
## Summary
- add meta description and semantic `<header>`/`<main>` to `index.html`
- replace missing media references with existing placeholder video and images
- move inline styles to `custom.css` and create utility classes
- update burger menus to use `<button>`
- replace `<b>` tags with `<strong>` for semantics

## Testing
- `grep -R "style=" *.html`

------
https://chatgpt.com/codex/tasks/task_e_6873ec57bec88325a92a173a590140a7