### PR TITLE
Add detailed pricing packages to services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -49,26 +49,241 @@
 <div class="container" style="max-width:950px;margin:2em auto 2em auto;">
 
   <div class="section" style="background:#e8f7f6;border-radius:12px;padding:2em;margin:2em 0;">
-    <h2 style="margin-top:0;">Dusk Emergence Survey Package</h2>
+    <h2 style="margin-top:0;">EchoSight Field &amp; Analysis Services</h2>
+    <p><b>Flexible. Precise. Defensible.</b> Professional-grade bat surveys and post-survey analysis for ecological consultancies that demand accuracy and real results.</p>
+
+    <h3>On-Site Survey Packages</h3>
+    <div class="table-wrapper">
+      <table class="alt">
+        <thead>
+          <tr><th>Package</th><th>What&#39;s Included</th><th>Key Deliverables</th><th>Price</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>On-Site Survey (Client Kit)</td>
+            <td>
+              <ul>
+                <li>Surveyor uses your equipment</li>
+                <li>30 min setup/clear-up</li>
+                <li>Up to 2 hrs on-site</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Live acoustic identification</li>
+                <li>Behavioural notes &amp; observations</li>
+                <li>Immediate written summary</li>
+              </ul>
+            </td>
+            <td>£175</td>
+          </tr>
+          <tr>
+            <td>On-Site Survey (EchoSight Kit)</td>
+            <td>
+              <ul>
+                <li>Surveyor uses EchoSight kit (Pixfra A625P, Batlogger M2)</li>
+                <li>All equipment provided</li>
+                <li>30 min setup/clear-up</li>
+                <li>Up to 2 hrs on-site</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Live acoustic identification</li>
+                <li>Behavioural notes &amp; observations</li>
+                <li>Immediate written summary</li>
+                <li>Shared raw video and audio recordings</li>
+              </ul>
+            </td>
+            <td>£250</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Premium &amp; Analysis Add-Ons</h3>
+    <div class="table-wrapper">
+      <table class="alt">
+        <thead>
+          <tr><th>Package/Service</th><th>What&#39;s Included</th><th>Key Deliverables</th><th>Price</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Premium Review (Client Kit)</td>
+            <td>
+              <ul>
+                <li>On-site survey (Client Kit)</li>
+                <li>Full post-survey analysis (up to 2 hrs data)</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>All Client Kit deliverables</li>
+                <li>Full acoustic &amp; video analysis</li>
+                <li>Comprehensive activity report</li>
+                <li>Annotated frames/screenshots</li>
+                <li>Confirmed species ID</li>
+                <li>Integrated results</li>
+              </ul>
+            </td>
+            <td>£300</td>
+          </tr>
+          <tr>
+            <td>Premium Review (EchoSight Kit)</td>
+            <td>
+              <ul>
+                <li>On-site survey (EchoSight Kit)</li>
+                <li>Full EchoSight Tracker motion review, mapping &amp; ID report (up to 2 hrs field, 2 hrs review)</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>All EchoSight Kit deliverables</li>
+                <li>Full acoustic &amp; video analysis</li>
+                <li>Comprehensive activity report</li>
+                <li>Annotated frames/screenshots</li>
+                <li>Confirmed species ID</li>
+                <li>Integrated results</li>
+              </ul>
+            </td>
+            <td>£325</td>
+          </tr>
+          <tr>
+            <td>Dual Deployment + Full Analysis</td>
+            <td>
+              <ul>
+                <li>2x thermal + 2x acoustic units deployed (no live observation)</li>
+                <li>30 min setup/clear-up</li>
+                <li>Full post-survey analysis (up to 2 hrs/device)</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>All equipment deployed &amp; collected</li>
+                <li>Full analysis for all units</li>
+                <li>Complete site activity mapping</li>
+                <li>Annotated &amp; interpreted results</li>
+                <li>Integrated, defensible reporting</li>
+              </ul>
+            </td>
+            <td>£450</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Remote Analysis Services</h3>
+    <div class="table-wrapper">
+      <table class="alt">
+        <thead>
+          <tr><th>Service</th><th>What&#39;s Included</th><th>Key Deliverables</th><th>Price</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>EchoSight Tracker (per video)</td>
+            <td>
+              <ul>
+                <li>Ecologist-led motion analysis of thermal video (up to 2 hrs/video)</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Motion analysis</li>
+                <li>Entry/emergence reporting</li>
+                <li>Annotated bat activity paths</li>
+                <li>Timestamped footage</li>
+                <li>Highlight reel</li>
+              </ul>
+            </td>
+            <td>£75</td>
+          </tr>
+          <tr>
+            <td>Species ID Report</td>
+            <td>
+              <ul>
+                <li>Manual review of full-spectrum acoustic recordings (up to 2 hrs)</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Manual species-level identification</li>
+                <li>Annotated audio review</li>
+                <li>Classified &amp; analysed reports</li>
+              </ul>
+            </td>
+            <td>£75</td>
+          </tr>
+          <tr>
+            <td>Combined Review (1 survey)</td>
+            <td>
+              <ul>
+                <li>Integrated analysis of thermal + audio (1x camera, 1x detector; up to 2 hrs each)</li>
+                <li>Extra: £35/hr</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>Integrated thermal &amp; acoustic analysis</li>
+                <li>Full report with motion paths &amp; species ID</li>
+              </ul>
+            </td>
+            <td>£200</td>
+          </tr>
+          <tr>
+            <td>Bulk Analysis Discounts</td>
+            <td>
+              <ul>
+                <li>For 5+ survey sites or multi-night projects</li>
+                <li>Price per site, varies by scale</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>All above, scaled for project scope</li>
+                <li>Priority turnaround</li>
+              </ul>
+            </td>
+            <td>from £180/site</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h3>Additional Information</h3>
     <ul>
-      <li>Professional <b>thermal imaging</b> with Pixfra ARC LRF A625 Pro</li>
-      <li><b>Full-spectrum acoustic monitoring</b> (BatLogger M2)</li>
-      <li>Automated video analysis using in-house <b>Echosight Motion Tracker</b></li>
-      <li>Real-time and post-survey data review for emergence confirmation</li>
-      <li><b>Consultant-ready report:</b> timestamped figures, mapped emergence events, species list, site recommendations</li>
-      <li>Follow-up Q&A and data support</li>
+      <li>All packages include 30 minutes for equipment setup and clear-up as standard.</li>
+      <li>On-site survey time is exclusive of setup/clear-up—your 2 hours is all field time.</li>
+      <li>Up to 120 miles total travel included at £0.45/mile; additional mileage charged at £0.45/mile.</li>
+      <li>Dual Deployment: Technician ensures on-site setup for both kits; analysis is post-survey only.</li>
+      <li>Dawn or unsociable hours: +£40 surcharge per event.</li>
+      <li>Overnight stays required for sites over 90 minutes from Newbury; additional cost applies.</li>
+      <li>Discounted bundles available for multi-phase or long-term projects.</li>
+      <li>All analysis assumes up to 2 hrs data per device per survey. Additional/complex data: £35/hr.</li>
+      <li>You pay for accuracy, not corner cutting. Every survey and review delivered to the highest professional standard.</li>
     </ul>
-    <div style="font-size:1.5em;font-weight:bold;color:#222;margin-top:1em;">£395</div>
-    <div>Within 60 miles of Newbury. Additional mileage at £0.45/mile.</div>
-  </div>
-  <div class="section">
-    <h2>Additional Services</h2>
+
+    <h3>Looking for Something Bespoke?</h3>
+    <p>Not seeing the exact fit for your project? EchoSight offers tailored survey and analysis packages for unique sites, research projects, or complex requirements.</p>
+    <p>How it works:</p>
     <ul>
-      <li>Additional visit/repeat survey: <b>£295</b></li>
-      <li>Custom AI video analysis of third-party footage: <b>Enquire</b></li>
-      <li>Specialist data review or reporting: <b>Enquire</b></li>
-      <li>Other protected species survey support: <b>Enquire</b></li>
+      <li>We’ll discuss your site, objectives, and constraints</li>
+      <li>I’ll design a custom scope, schedule, and reporting plan—no recycled templates, ever</li>
+      <li>Transparent, upfront quote before you commit</li>
     </ul>
+    <p>You get:</p>
+    <ul>
+      <li>Direct access to Jack (lead ecologist &amp; consultant)</li>
+      <li>The best tech, methods, and analysis for your situation</li>
+      <li>Uncompromising data quality, always defensible</li>
+    </ul>
+    <a href="contact.html" class="cta-btn">Request a Bespoke Proposal</a>
   </div>
   <div class="section" style="margin-bottom:2em;">
     <h2>Sample Footage & Reports</h2>


### PR DESCRIPTION
## Summary
- replace old service list with full pricing packages
- show on-site survey, premium add-ons, and remote analysis tables
- include additional information and bespoke proposal section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ed34c1cc8325a425604258cb2927