### PR TITLE
Fix mobile alignment for form inputs

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -331,6 +331,8 @@ img {
   padding: 0.7em;
   border-radius: 5px;
   border: 1px solid #bbb;
+  width: 100%;
+  box-sizing: border-box;
 }
 .btn-narrow {
   width: 150px;


### PR DESCRIPTION
## Summary
- expand `.input-field` style so contact form text boxes use the full container width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740282db3c8325a66373ecc3a2c79d