### PR TITLE
Add About page video

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="assets/css/main.css">
   <link rel="stylesheet" href="assets/css/custom.css">
   <link rel="icon" href="images/favicon.ico">
-  <meta name="description" content="Learn about Echosight and Jack Curry's expertise in thermal imaging and acoustic analysis for ecological surveys." />
+  <meta name="description" content="Learn about Echosight and Jack Curry's expertise in thermal imaging, acoustic analysis, project and operations management, and workflow improvement for ecological surveys." />
 </head>
 <!-- NAVIGATION (BURGER MENU) -->
 <!-- NAVIGATION (BURGER MENU WITH LOGO) -->
@@ -43,9 +43,9 @@
       <p>
         Hi, I'm Jack Curry – an experienced bat ecologist and evidence-focused consultant based in Newbury. With over a decade’s experience working in UK ecology, I specialise in delivering high-sensitivity bat surveys and robust, traceable reporting for ecological consultancies.
       </p>
-      <p>
-        My background combines protected species survey work, digital data collection, and workflow design. I have developed and refined specialist bat survey methodologies that pair the best of hands-on expertise with powerful analysis tools – ensuring no bats are missed and every result is traceable, audit-ready, and easy for clients to use.
-      </p>
+        <p>
+          My background combines protected species survey work, digital data collection, project and operations management, and workflow design. By focusing on workflow improvement and identifying the best tools for the job, I’ve developed specialist bat survey methodologies that pair hands-on expertise with powerful analysis tools – ensuring no bats are missed and every result is traceable, audit-ready, and easy for clients to use.
+        </p>
       <ul>
         <li><strong>Bat survey specialist</strong> with advanced thermal and acoustic techniques</li>
         <li><strong>Evidence-based</strong> approach: transparent, reproducible, and client-focused</li>
@@ -54,6 +54,15 @@
 
     </div>
   </div>
+</div>
+
+<!-- About Video Section -->
+<div class="container about-video">
+  <h2>Watch Jack in Action</h2>
+  <video controls class="media-rounded" width="100%">
+    <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
 </div>
 
 

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -382,6 +382,16 @@ img {
   border-radius: 10px;
   box-shadow: 0 2px 14px rgba(30,30,45,0.08);
 }
+.about-video {
+  text-align: center;
+  margin: 2em auto;
+  max-width: 700px;
+}
+.about-video video {
+  width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1);
+}
 .stacked-list {
   line-height: 1.6;
 }


### PR DESCRIPTION
## Summary
- add video section to about page
- style new about-video component
- expand bio with project management background

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68741ec7651483259c1b313f229c2646