### PR TITLE
Move pricing to new page

### DIFF
--- a/about.html
+++ b/about.html
@@ -21,6 +21,7 @@
     <div class="menu-links" id="mainMenu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
+      <a href="pricing.html">Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/contact.html
+++ b/contact.html
@@ -22,6 +22,7 @@
     <div class="menu-links" id="mainMenu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
+      <a href="pricing.html">Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <div class="menu-links" id="mainMenu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
+      <a href="pricing.html">Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>
@@ -129,13 +130,8 @@
 <!-- Pricing/Packages (Contained) -->
 <section class="container pricing">
   <h2>Transparent Pricing &amp; Packages</h2>
-  <ul>
-    <li><strong>On-Site Surveys:</strong> From £175</li>
-    <li><strong>Premium Analysis:</strong> From £300</li>
-    <li><strong>Remote Review:</strong> From £75</li>
-    <li><strong>Bulk &amp; Bespoke Solutions:</strong> Priced to scale with your project</li>
-  </ul>
-  <p>[<a href="services.html">See Full Pricing</a>] | [<a href="contact.html">Request a Proposal</a>]</p>
+  <p>On-site surveys from £175, premium analysis from £300 and remote review from £75.</p>
+  <p>[<a href="pricing.html">See Full Pricing</a>] | [<a href="contact.html">Request a Proposal</a>]</p>
 </section>
 
 <!-- Why Choose Echosight/Testimonials (Contained) -->

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pricing | Echosight</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/custom.css">
+  <link rel="icon" href="images/favicon.ico">
+  <meta name="description" content="Pricing for EchoSight survey packages and analysis services." />
+</head>
+<body>
+<!-- NAVIGATION (BURGER MENU WITH LOGO) -->
+<header>
+<nav class="nav-bar">
+  <div class="nav-content">
+    <span class="logo-area">
+      <img src="images/Echosight-logo.svg" alt="Echosight Logo" class="logo-img">
+      <a class="logo-text" href="index.html">Echosight</a>
+    </span>
+    <div class="menu-links" id="mainMenu">
+      <a href="index.html">Home</a>
+      <a href="services.html">Services</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="about.html">About</a>
+      <a href="resources.html">Resources</a>
+      <a href="contact.html">Contact</a>
+    </div>
+    <button class="burger" id="burgerBtn" aria-label="Open menu">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+</header>
+
+<div class="container pricing">
+  <h1>Transparent Pricing &amp; Packages</h1>
+  <ul>
+    <li><strong>On-Site Surveys:</strong> From £175</li>
+    <li><strong>Premium Analysis:</strong> From £300</li>
+    <li><strong>Remote Review:</strong> From £75</li>
+    <li><strong>Bulk &amp; Bespoke Solutions:</strong> Priced to scale with your project</li>
+  </ul>
+  <p><a href="services.html">See Full Service Details</a> | <a href="contact.html">Request a Proposal</a></p>
+</div>
+
+<footer class="site-footer">
+  &copy; 2025 Echosight by Jack Curry. | <a href="https://www.instagram.com/echosight.uk/" target="_blank">Instagram</a> | <a href="contact.html">Contact</a>
+  <script src="assets/js/nav.js"></script>
+</footer>
+</body>
+</html>

--- a/resources.html
+++ b/resources.html
@@ -21,6 +21,7 @@
     <div class="menu-links" id="mainMenu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
+      <a href="pricing.html">Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/services.html
+++ b/services.html
@@ -21,6 +21,7 @@
     <div class="menu-links" id="mainMenu">
       <a href="index.html">Home</a>
       <a href="services.html">Services</a>
+      <a href="pricing.html">Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>


### PR DESCRIPTION
## Summary
- add dedicated `pricing.html` page with pricing details
- shorten the pricing section on `index.html`
- link to full pricing page
- add `Pricing` link in the navigation across the site

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68742a063fa88325b08cab0e54f13127