### PR TITLE
Apply italics styling to Additional Information section

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -421,3 +421,10 @@ img {
   font-weight: bold;
   white-space: nowrap;
 }
+
+/* Fine print or terms and conditions style */
+.fine-print {
+  font-style: italic;
+  font-size: 0.9em;
+  color: #555;
+}

--- a/services.html
+++ b/services.html
@@ -150,7 +150,7 @@
 
   <div class="section">
     <h2>Additional Information</h2>
-    <ul class="stacked-list">
+    <ul class="stacked-list fine-print">
       <li>All packages include 30 minutes for equipment setup and clear-up as standard.</li>
       <li>On-site survey time is exclusive of setup/clear-up—your 2 hours is all field time.</li>
       <li>Up to 120 miles total travel included at £0.45/mile; additional mileage charged at £0.45/mile.</li>


### PR DESCRIPTION
## Summary
- add `.fine-print` class with italic styling to give terms-and-conditions look
- apply the class to the Additional Information list in `services.html`

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68742d51e76483259ebc73ffc07c5337