### PR TITLE
Implement flexbox layout for bottlenecks

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -440,20 +440,25 @@ img {
 }
 
 /* Bottlenecks layout helpers */
-.bottlenecks > div::after {
-  content: "";
+.bottleneck-item {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  margin-bottom: 1.5em;
+}
+
+.bottleneck-item:nth-child(even) {
+  flex-direction: row-reverse;
+}
+
+.bottleneck-item img {
   display: block;
-  clear: both;
+  width: 100%;
+  height: auto;
 }
 
-.left {
-  float: left;
-  margin-right: 1em;
-}
-
-.right {
-  float: right;
-  margin-left: 1em;
+.bottleneck-img {
+  flex-shrink: 0;
 }
 
 .small-width {
@@ -472,4 +477,15 @@ img {
   width: 100%;
   height: auto;
   display: block;
+}
+
+@media (max-width: 600px) {
+  .bottleneck-item,
+  .bottleneck-item:nth-child(even) {
+    flex-direction: column;
+    text-align: center;
+  }
+  .bottleneck-img {
+    margin: 0 0 1em 0;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -52,33 +52,41 @@
 <section class="container feature-box">
   <h2 class="highlight-title">Your Bottlenecks, Solved</h2>
   <div class="bottlenecks">
-    <div>
-      <aside class="right small-width small-height padding">
+    <div class="bottleneck-item">
+      <aside class="bottleneck-img small-width small-height padding">
         <img class="responsive" src="/beer-and-woman.jpg" alt="">
       </aside>
-      <h5>Survey Capacity Constraints</h5>
-      <p>Need qualified surveyors at short notice? EchoSight provides rapid-response, fully equipped field teams for standard and complex bat surveys—on your terms, with your kit or ours.</p>
+      <div>
+        <h5>Survey Capacity Constraints</h5>
+        <p>Need qualified surveyors at short notice? EchoSight provides rapid-response, fully equipped field teams for standard and complex bat surveys—on your terms, with your kit or ours.</p>
+      </div>
     </div>
-    <div>
-      <aside class="left small-width small-height padding">
+    <div class="bottleneck-item">
+      <aside class="bottleneck-img small-width small-height padding">
         <img class="responsive" src="/beer-and-woman.jpg" alt="">
       </aside>
-      <h5>Analysis Overload</h5>
-      <p>Struggling to keep up with data review and reporting? Our ecologist-led pipeline turns raw acoustic and thermal data into actionable insights and defensible reports—on time, every time.</p>
+      <div>
+        <h5>Analysis Overload</h5>
+        <p>Struggling to keep up with data review and reporting? Our ecologist-led pipeline turns raw acoustic and thermal data into actionable insights and defensible reports—on time, every time.</p>
+      </div>
     </div>
-    <div>
-      <aside class="right small-width small-height padding">
+    <div class="bottleneck-item">
+      <aside class="bottleneck-img small-width small-height padding">
         <img class="responsive" src="/beer-and-woman.jpg" alt="">
       </aside>
-      <h5>Unpredictable Costs</h5>
-      <p>Tired of moving targets and hidden extras? EchoSight delivers transparent, upfront pricing for all packages, with clear deliverables and predictable fees—even on challenging projects.</p>
+      <div>
+        <h5>Unpredictable Costs</h5>
+        <p>Tired of moving targets and hidden extras? EchoSight delivers transparent, upfront pricing for all packages, with clear deliverables and predictable fees—even on challenging projects.</p>
+      </div>
     </div>
-    <div>
-      <aside class="left small-width small-height padding">
+    <div class="bottleneck-item">
+      <aside class="bottleneck-img small-width small-height padding">
         <img class="responsive" src="/beer-and-woman.jpg" alt="">
       </aside>
-      <h5>Quality Assurance</h5>
-      <p>Concerned about regulatory scrutiny? Every EchoSight report is built for compliance, using specialist equipment and rigorous, custom analysis workflows.</p>
+      <div>
+        <h5>Quality Assurance</h5>
+        <p>Concerned about regulatory scrutiny? Every EchoSight report is built for compliance, using specialist equipment and rigorous, custom analysis workflows.</p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- refactor CSS to switch bottleneck layout from floats to flexbox
- wrap bottleneck text and images in `.bottleneck-item` containers
- add responsive rule to stack items vertically on narrow screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874c6a8dabc8325b0e6a16146148290