### PR TITLE
Improve index services section with video overlays

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -489,3 +489,62 @@ img {
     margin: 0 0 1em 0;
   }
 }
+
+/* Service Section Styles */
+.services-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5em;
+  justify-content: center;
+}
+.service-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 18px rgba(0,0,0,0.09);
+  overflow: hidden;
+  max-width: 320px;
+  flex: 1 1 280px;
+  display: flex;
+  flex-direction: column;
+}
+.service-media {
+  position: relative;
+  height: 180px;
+  overflow: hidden;
+}
+.service-media video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.service-title {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  font-size: 1.3em;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.6);
+  pointer-events: none;
+}
+.service-card p {
+  padding: 1em 1.2em 1.6em;
+  margin: 0;
+  color: #222;
+  flex-grow: 1;
+}
+.service-btn {
+  display: block;
+  width: max-content;
+  margin: 2em auto 0;
+}
+@media (max-width: 900px) {
+  .service-media {
+    height: 160px;
+  }
+  .service-title {
+    font-size: 1.1em;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -49,39 +49,38 @@
 </section>
 
 <!-- Feature Cards Section (Contained) -->
-<section class="container feature-box">
+<section class="container feature-box" id="services">
   <h2 class="highlight-title">Our Services</h2>
-    <div class="see-diff-cards">
-    <div>
-      <video controls width="100%" class="media-frame">
-        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
-      </video>
-    </div>
-    <div>
-      <video controls width="100%" class="media-frame">
-        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
-      </video>
-    </div>
-    <div>
-      <video controls width="100%" class="media-frame">
-        <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
-      </video>
-    </div>
+  <div class="services-grid">
+    <article class="service-card">
+      <div class="service-media">
+        <video autoplay muted loop playsinline>
+          <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
+        </video>
+        <h3 class="service-title">On-Site Bat Surveys</h3>
+      </div>
+      <p>Immediate on-site identification with rapid reporting.</p>
+    </article>
+    <article class="service-card">
+      <div class="service-media">
+        <video autoplay muted loop playsinline>
+          <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
+        </video>
+        <h3 class="service-title">Post-Survey Analysis</h3>
+      </div>
+      <p>Detailed thermal and acoustic review for defensible species ID.</p>
+    </article>
+    <article class="service-card">
+      <div class="service-media">
+        <video autoplay muted loop playsinline>
+          <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
+        </video>
+        <h3 class="service-title">Remote Analysis</h3>
+      </div>
+      <p>Send us your data for independent, integrated reporting.</p>
+    </article>
   </div>
-  <div class="feature-cards">
-    <div class="feature-card">
-      <h3>On-Site Bat Surveys</h3>
-      <p>Standard and premium packages, with or without your own equipment. Immediate on-site identification, professional field notes, and rapid reporting.</p>
-    </div>
-    <div class="feature-card">
-      <h3>Post-Survey Analysis</h3>
-      <p>Full-spectrum acoustic and thermal review. Utilising EchoSight’s advanced tracking software and expert review for reliable species ID and activity mapping.</p>
-    </div>
-    <div class="feature-card">
-      <h3>Remote Analysis</h3>
-      <p>Send us your field data—get independent, defensible analysis and integrated reporting.</p>
-    </div>
-  </div>  
+  <a href="services.html" class="cta-btn service-btn">Explore Full Service Details</a>
   <p class="section-note">All bat survey footage and analyses are generated in-house using Echosight’s own equipment and AI workflow.</p>
 </section>
 


### PR DESCRIPTION
## Summary
- redesign the "Our Services" section
- overlay service titles on looping videos
- add concise descriptions and link to services page
- style new service cards in `custom.css`

## Testing
- `apt-get install -y ed`


------
https://chatgpt.com/codex/tasks/task_e_6874d80d54ac832597b1752dd8db0c1f