### PR TITLE
Center and lighten hero overlay text

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -40,7 +40,14 @@ img {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  text-align: center;
   color: #fff;
+}
+
+.hero-overlay h1,
+.hero-overlay h3 {
+  font-weight: 300;
+  color: #f7f7f7;
 }
 
 .cta-btn {


### PR DESCRIPTION
## Summary
- ensure hero overlay text is centered
- lighten hero overlay text and use consistent formatting

## Testing
- `grep -n "hero-overlay" -R *.html`

------
https://chatgpt.com/codex/tasks/task_e_6874ebfcdb9883258e23bdb8ea2cf42d