### PR TITLE
Fix hero headings and add descriptive h1s

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,7 +41,7 @@
     <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
   </video>
   <div class="hero-overlay">
-<h1>EchoSight Field & Analysis Services</h1>
+<h2>EchoSight Field & Analysis Services</h2>
       <h3>Flexible. Precise. Defensible. Professional-grade bat surveys and post-survey analysis for ecological consultancies that demand accuracy and traceable results</h3>
       <a href="contact.html" class="cta-btn">Book a Consultation</a>
   </div>
@@ -49,6 +49,7 @@
 
 <!-- About/Trust Section (Contained) -->
 <div class="container section about-box">
+  <h1>About EchoSight</h1>
   <div class="about-row">
     <img src="images/header.jpg" class="about-img" alt="Jack Curry">
     <div>

--- a/contact.html
+++ b/contact.html
@@ -42,14 +42,14 @@
     <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
   </video>
   <div class="hero-overlay">
-<h1>EchoSight Field & Analysis Services</h1>
+<h2>EchoSight Field & Analysis Services</h2>
       <h3>Flexible. Precise. Defensible. Professional-grade bat surveys and post-survey analysis for ecological consultancies that demand accuracy and traceable results</h3>
       <a href="contact.html" class="cta-btn">Book a Consultation</a>
   </div>
 </section>
 
 <div class="container contact-box">
-  <h1>Contact Me</h1>
+  <h1>Contact EchoSight</h1>
   <p>
     Interested in working together, booking a survey, or requesting a sample report? Get in touch below or email <strong>jack.curry@echosight.co.uk</strong> directly.
   </p>

--- a/resources.html
+++ b/resources.html
@@ -41,7 +41,7 @@
     <source src="assets/videos/echosight-hero-placeholder.mp4" type="video/mp4">
   </video>
   <div class="hero-overlay">
-<h1>EchoSight Field & Analysis Services</h1>
+<h2>EchoSight Field & Analysis Services</h2>
       <h3>Flexible. Precise. Defensible. Professional-grade bat surveys and post-survey analysis for ecological consultancies that demand accuracy and traceable results</h3>
       <a href="contact.html" class="cta-btn">Book a Consultation</a>
   </div>


### PR DESCRIPTION
## Summary
- downgrade hero headings to `<h2>` outside the homepage
- add descriptive `<h1>` to About page and adjust Contact heading

## Testing
- `grep -n '<h1' *.html`

------
https://chatgpt.com/codex/tasks/task_e_68750794a97083258c96d4ae6c4a0b48