### PR TITLE
Add logo to Why Partner section

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -764,6 +764,30 @@ blockquote.testimonial cite {
   display: block;
 }
 
+/* Layout for Why Partner section */
+.why-echosight .why-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.why-echosight .why-logo {
+  max-width: 220px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 700px) {
+  .why-echosight .why-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .why-echosight .why-logo {
+    align-self: center;
+    margin-top: 1rem;
+  }
+}
+
 /* === CTA Buttons === */
 .cta-btn, .cta-btn.service-btn {
   display: inline-block;

--- a/index.html
+++ b/index.html
@@ -106,13 +106,18 @@
 
 <!-- Why Choose EchoSight/Testimonials -->
 <section class="container why-echosight">
-  <h2 class="highlight-title">Why Partner with EchoSight?</h2>
-  <ul class="stacked-list">
-    <li><strong>Proven Track Record:</strong> Trusted by leading consultancies for high-stakes projects and tight timelines.</li>
-    <li><strong>Flexible Integration:</strong> Services designed to fit your team’s needs, scale, and systems.</li>
-    <li><strong>Expert-Led:</strong> Direct access to a licensed bat specialist—no handoffs, no lost detail.</li>
-    <li><strong>Predictable Turnaround:</strong> Set timelines, guaranteed delivery, and responsive communication.</li>
-  </ul>
+  <div class="why-row">
+    <div class="why-text">
+      <h2 class="highlight-title">Why Partner with EchoSight?</h2>
+      <ul class="stacked-list">
+        <li><strong>Proven Track Record:</strong> Trusted by leading consultancies for high-stakes projects and tight timelines.</li>
+        <li><strong>Flexible Integration:</strong> Services designed to fit your team’s needs, scale, and systems.</li>
+        <li><strong>Expert-Led:</strong> Direct access to a licensed bat specialist—no handoffs, no lost detail.</li>
+        <li><strong>Predictable Turnaround:</strong> Set timelines, guaranteed delivery, and responsive communication.</li>
+      </ul>
+    </div>
+    <img src="images/Echosight-logo.svg" alt="EchoSight logo" class="why-logo">
+  </div>
   <blockquote class="testimonial">
     <p>“EchoSight’s support has doubled our survey capacity and eliminated our post-season reporting backlog. Every deadline met, every report bulletproof.”</p>
     <cite>&mdash; Director, Regional Ecological Consultancy</cite>


### PR DESCRIPTION
## Summary
- place Why Partner content and logo in a flex row
- style Why Partner section with responsive layout

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68750f12531483258ecd4727520ceffb