### PR TITLE
Add motion highlights service pricing

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -122,6 +122,12 @@
             <td><ul class="stacked-list"><li>Motion analysis</li><li>Entry/emergence reporting</li><li>Annotated bat activity paths</li><li>Timestamped footage</li><li>Highlight reel</li></ul></td>
             <td class="price">£75</td>
           </tr>
+            <tr>
+              <td>Motion Highlights (per video)</td>
+              <td><ul class="stacked-list"><li>Footage processing to isolate motion events (up to 2 hrs/video)</li><li>Static periods trimmed out</li><li>Extra: £35/hr</li></ul></td>
+              <td><ul class="stacked-list"><li>Condensed video of motion-only segments</li><li>Timestamped event log</li></ul></td>
+              <td class="price">£40</td>
+            </tr>
           <tr>
             <td>Species ID Report</td>
             <td><ul class="stacked-list"><li>Manual review of full-spectrum acoustic recordings (up to 2 hrs)</li><li>Extra: £35/hr</li></ul></td>
@@ -158,6 +164,7 @@
       <li>Discounted bundles available for multi-phase or long-term projects.</li>
       <li>All analysis assumes up to 2 hrs data per device per survey. Additional/complex data: £35/hr.</li>
       <li>You pay for accuracy, not corner cutting. Every survey and review delivered to the highest professional standard.</li>
+      <li>High-resolution thermal footage (e.g., FLIR) may require large file transfers; hard drive exchange may be needed.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
## Summary
- extend Remote Analysis Services table with Motion Highlights service priced at £40
- add a note in Additional Information on handling large FLIR or high-resolution thermal footage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687678791f508325a7c904808ab75996