### PR TITLE
Align services layout with site grid style

### DIFF
--- a/services.html
+++ b/services.html
@@ -54,7 +54,7 @@
 <!-- Feature Cards Section (Contained) -->
 <section class="container feature-box">
   <h2 class="highlight-title">Our Services</h2>
-  <div class="services-stack">
+  <div class="services-grid">
     <article class="service-card" id="on-site-bat-surveys">
       <a href="#on-site-bat-surveys" class="service-media-link" aria-label="On-Site Bat Surveys">
         <div class="service-media">
@@ -92,7 +92,6 @@
       <a href="pricing.html#on-site-packages">View pricing for this service</a>
       <a href="resources.html" class="mt-1">See example outputs</a>
     </article>
-    <div class="down-arrow"><i class="fas fa-arrow-down"></i></div>
     <article class="service-card" id="post-survey-analysis">
       <a href="#post-survey-analysis" class="service-media-link" aria-label="Acoustic Analysis">
         <div class="service-media">
@@ -120,7 +119,6 @@
       <a href="pricing.html#remote-analysis-services">View pricing for this service</a>
       <a href="resources.html" class="mt-1">See example outputs</a>
     </article>
-    <div class="down-arrow"><i class="fas fa-arrow-down"></i></div>
     <article class="service-card" id="video-analysis">
       <a href="#video-analysis" class="service-media-link" aria-label="Video Emergence & Re-entry Analysis">
         <div class="service-media">
@@ -147,7 +145,6 @@
       <a href="pricing.html#remote-analysis-services">View pricing for this service</a>
       <a href="resources.html" class="mt-1">See example outputs</a>
     </article>
-    <div class="down-arrow"><i class="fas fa-arrow-down"></i></div>
     <article class="service-card" id="bespoke-solutions">
       <a href="#bespoke-solutions" class="service-media-link" aria-label="Bespoke Solutions">
         <div class="service-media">


### PR DESCRIPTION
## Summary
- switch services list to use the grid layout
- remove decorative down arrows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877b845f29883259994c800c37f71d4