### PR TITLE
Fix pricing formatting and travel notes

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -55,14 +55,17 @@
     <div class="table-wrapper">
       <table class="pricing-table">
         <thead>
-          <tr>
+          <tr><th>Package</th><th>What's Included</th><th>Key Deliverables</th><th>Price</th></tr>
+        </thead>
+        <tbody>
+        <tr>
         <td>On-Site Survey (Client Kit)</td>
         <td>
           <ul class="stacked-list">
             <li>Surveyor uses your equipment</li>
             <li>Up to 1 hr setup/clear-up (in addition to survey)</li>
             <li>Up to 2 hrs on-site survey</li>
-            <li>Mileage and travel time up to 120 miles included; extra miles £0.45/mile</li>
+            <li>Travel up to 2 hours included (approx. 120 miles); extra miles £0.45/mile</li>
             <li>Sites over 90 min from Newbury require overnight stay; extra cost applies</li>
             <li>Extra: £35/hr</li>
           </ul>
@@ -84,7 +87,7 @@
             <li>All equipment provided</li>
             <li>Up to 1 hr setup/clear-up (in addition to survey)</li>
             <li>Up to 2 hrs on-site survey</li>
-            <li>Mileage and travel time up to 120 miles included; extra miles £0.45/mile</li>
+            <li>Travel up to 2 hours included (approx. 120 miles); extra miles £0.45/mile</li>
             <li>Sites over 90 min from Newbury require overnight stay; extra cost applies</li>
             <li>Extra: £35/hr</li>
           </ul>
@@ -107,7 +110,7 @@
             <li>Full post-survey analysis (up to 2 hrs data)</li>
             <li>Up to 1 hr setup/clear-up (in addition to survey)</li>
             <li>Up to 2 hrs on-site survey</li>
-            <li>Mileage and travel time up to 120 miles included; extra miles £0.45/mile</li>
+            <li>Travel up to 2 hours included (approx. 120 miles); extra miles £0.45/mile</li>
             <li>Sites over 90 min from Newbury require overnight stay; extra cost applies</li>
             <li>Extra: £35/hr</li>
           </ul>
@@ -132,7 +135,7 @@
             <li>Full EchoSight Tracker motion review, mapping & ID report (up to 2 hrs field, 2 hrs review)</li>
             <li>Up to 1 hr setup/clear-up (in addition to survey)</li>
             <li>Up to 2 hrs on-site survey</li>
-            <li>Mileage and travel time up to 120 miles included; extra miles £0.45/mile</li>
+            <li>Travel up to 2 hours included (approx. 120 miles); extra miles £0.45/mile</li>
             <li>Sites over 90 min from Newbury require overnight stay; extra cost applies</li>
             <li>Extra: £35/hr</li>
           </ul>
@@ -156,7 +159,7 @@
             <li>2x thermal + 2x acoustic units deployed (no live observation)</li>
             <li>Up to 1 hr setup/clear-up (in addition to deployment/collection)</li>
             <li>Full post-survey analysis (up to 2 hrs/device)</li>
-            <li>Mileage and travel time up to 120 miles included; extra miles £0.45/mile</li>
+            <li>Travel up to 2 hours included (approx. 120 miles); extra miles £0.45/mile</li>
             <li>Sites over 90 min from Newbury require overnight stay; extra cost applies</li>
             <li>Extra: £35/hr</li>
           </ul>
@@ -176,7 +179,9 @@
         </tbody>
       </table>
     </div>
-    <p><a href="services.html" class="cta-btn btn-narrow">Return to Services</a></p>
+    <div class="text-center mt-1">
+      <a href="services.html" class="cta-btn btn-narrow">Return to Services</a>
+    </div>
   </div>
 
 
@@ -221,7 +226,9 @@
         </tbody>
       </table>
     </div>
-    <p><a href="services.html" class="cta-btn btn-narrow">Return to Services</a></p>
+    <div class="text-center mt-1">
+      <a href="services.html" class="cta-btn btn-narrow">Return to Services</a>
+    </div>
   </div>
 
   <div class="section">
@@ -229,7 +236,7 @@
     <ul class="stacked-list fine-print">
       <li>All packages include 30 minutes for equipment setup and clear-up as standard.</li>
       <li>On-site survey time is exclusive of setup/clear-up—your 2 hours is all field time.</li>
-      <li>Up to 120 miles total travel included at £0.45/mile; additional mileage charged at £0.45/mile.</li>
+      <li>Travel up to 2 hours included (approx. 120 miles); additional mileage charged at £0.45/mile.</li>
       <li>Dual Deployment: Technician ensures on-site setup for both kits; analysis is post-survey only.</li>
       <li>Dawn or unsociable hours: +£40 surcharge per event.</li>
       <li>Overnight stays required for sites over 90 minutes from Newbury; additional cost applies.</li>
@@ -255,7 +262,9 @@
       <li>The best tech, methods, and analysis for your situation</li>
       <li>Uncompromising data quality, always defensible</li>
     </ul>
-    <p><a href="contact.html" class="cta-btn btn-narrow">Request a Bespoke Proposal</a></p>
+    <div class="text-center mt-1">
+      <a href="contact.html" class="cta-btn btn-narrow">Request a Bespoke Proposal</a>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- fix pricing table markup so headers render correctly
- add text centering wrappers around pricing page CTA buttons
- clarify travel allowance now includes up to 2 hours

## Testing
- `tidy -q -e pricing.html`

------
https://chatgpt.com/codex/tasks/task_e_688242c122108325a3245f2dd5e2fb24