### PR TITLE
Fix responsive layouts for services and equipment

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -558,7 +558,7 @@ img {
 /* Service Section Styles */
 .services-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 2rem;
   justify-items: stretch;
   grid-auto-rows: 1fr;
@@ -612,6 +612,9 @@ img {
   margin: 2em auto 0;
 }
 @media (max-width: 900px) {
+  .services-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
   .service-media {
     height: 160px;
   }
@@ -670,7 +673,7 @@ h2, h3 {
 /* === Service Cards Section === */
 .services-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 2rem;
   justify-items: stretch;
   margin-bottom: 2rem;
@@ -844,7 +847,7 @@ blockquote.testimonial cite {
 /* === Responsive Styles === */
 @media (max-width: 600px) {
   .services-grid {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     gap: 2rem;
   }
   .service-card, .service-media, .video-wrapper {


### PR DESCRIPTION
## Summary
- tweak `.services-grid` to use `auto-fit` so cards shrink gracefully
- update responsive breakpoints for 2-column and 1-column layouts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a70d13508325af7ea19d56733841