### PR TITLE
Rename Pricing page link

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,7 +22,7 @@
       </span>
     </span>
     <div class="menu-links" id="mainMenu">
-      <a href="pricing.html">Pricing</a>
+      <a href="pricing.html">Services & Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/contact.html
+++ b/contact.html
@@ -23,7 +23,7 @@
       </span>
     </span>
     <div class="menu-links" id="mainMenu">
-      <a href="pricing.html">Pricing</a>
+      <a href="pricing.html">Services & Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </span>
       </span>
       <div class="menu-links" id="mainMenu">
-        <a href="pricing.html">Pricing</a>
+        <a href="pricing.html">Services & Pricing</a>
         <a href="about.html">About</a>
         <a href="resources.html">Resources</a>
         <a href="contact.html">Contact</a>

--- a/pricing.html
+++ b/pricing.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Pricing | EchoSight</title>
+  <title>Services & Pricing | EchoSight</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="assets/css/main.css">
   <link rel="stylesheet" href="assets/css/custom.css">
@@ -42,7 +42,7 @@
   </video>
   <div class="hero-overlay">
     <div class="hero-text">
-      <h1>Survey Pricing</h1>
+      <h1>Services & Pricing</h1>
       <h3>Upfront pricing with no surprises.</h3>
       <a href="contact.html" class="cta-btn">Request a Quote</a>
     </div>

--- a/resources.html
+++ b/resources.html
@@ -22,7 +22,7 @@
       </span>
     </span>
     <div class="menu-links" id="mainMenu">
-      <a href="pricing.html">Pricing</a>
+      <a href="pricing.html">Services & Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/services-hidden.html
+++ b/services-hidden.html
@@ -22,7 +22,7 @@
       </span>
     </span>
     <div class="menu-links" id="mainMenu">
-      <a href="pricing.html">Pricing</a>
+      <a href="pricing.html">Services & Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>

--- a/surveys-hidden.html
+++ b/surveys-hidden.html
@@ -22,7 +22,7 @@
       </span>
     </span>
     <div class="menu-links" id="mainMenu">
-      <a href="pricing.html">Pricing</a>
+      <a href="pricing.html">Services & Pricing</a>
       <a href="about.html">About</a>
       <a href="resources.html">Resources</a>
       <a href="contact.html">Contact</a>


### PR DESCRIPTION
## Summary
- rename "Pricing" navigation label across site to "Services & Pricing"
- update pricing page title and heading

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_688a4e04b28c8325a1b4e86a151c5c73