### PR TITLE
Add remote analysis section to pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -191,6 +191,24 @@
         </tbody>
       </table>
     </div>
+  <!-- Remote Analysis Introduction -->
+  <section class="container intro-blurb" id="remote-analysis-intro">
+    <h2 class="highlight-title">Remote Analysis Services</h2>
+    <p>Send the data. We’ll handle the detail.</p>
+    <p>EchoSight offers remote post-processing for existing survey data, whether acoustic or video-based.</p>
+    <h3>🔊 Acoustic Analysis</h3>
+    <p>Upload your full-spectrum or zero-crossing recordings. We’ll process them using BatExplorer, Kaleidoscope, or BatSound—depending on your device. Expect annotated species IDs, call metrics, and summaries focused on what's relevant to your project.</p>
+    <h3>🎥 Thermal Video Review</h3>
+    <p>Using our EchoSight Tracker software, we analyse your thermal or IR footage, OneDrive relevant motion, marking up species-specific activity and behaviour patterns. The output? Clear, time-stamped annotations and ecological insights you can actually use in reports, licensing, or impact assessments.</p>
+    <p>Once the scope and deadlines are agreed, you’ll receive:</p>
+    <ul class="stacked-list">
+      <li>A full invoice breakdown</li>
+      <li>A secure OneDrive link for uploading your files</li>
+      <li>A delivery date you can count on</li>
+    </ul>
+    <hr>
+    <p>Want to discuss your project first? <a href="contact.html">Contact us here</a> or jump straight in with <a href="contact.html">Book Now</a>.</p>
+  </section>
   <div class="section" id="remote-analysis-services">
     <h2>Video and Acoustic Data Review & Reporting</h2>
     <div class="table-wrapper">


### PR DESCRIPTION
## Summary
- introduce "Remote Analysis Services" intro block on the pricing page above the remote section

## Testing
- `tidy -errors pricing.html`
- `tidy -errors services-hidden.html`


------
https://chatgpt.com/codex/tasks/task_e_688b8de0bca883258187a646782a0476