### PR TITLE
Add hidden Resources link for EchoSight PNG logo

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -163,6 +163,10 @@
     </div>
   </section>
 
+  <section class="visually-hidden" aria-label="Hidden direct resource links">
+    <a href="images/echosight_logo.png">Download EchoSight logo (PNG)</a>
+  </section>
+
   <section class="section cta-band" aria-labelledby="cta-heading">
     <div class="container">
       <div class="cta-band__content">


### PR DESCRIPTION
### Motivation
- Provide a stable, website-relative URL for the newly added PNG logo while keeping the link out of normal page layout so it can be used by the site or assets consumers.

### Description
- Add a visually hidden section to `resources.html` containing an anchor linking to `images/echosight_logo.png` so the file is addressable from the live site.

### Testing
- Verified the asset exists with `test -f images/echosight_logo.png && echo 'png exists'` and confirmed `resources.html` contains the hidden anchor via `nl -ba resources.html | sed -n '150,195p'`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ead237d08325871ae48eb325d35a)