### PR TITLE
Update mileage pricing to £0.55 per mile

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -189,7 +189,7 @@
         <div class="pricing-travel-note">
           <h3 class="pricing-travel-note__title">Travel &amp; accommodation (outside packages)</h3>
           <p class="es-muted">
-            Survey packages are priced excluding travel. Travel is added from Newbury at <strong>£0.45/mi</strong> plus <strong>£33/hr travel time</strong>.
+            Survey packages are priced excluding travel. Travel is added from Newbury at <strong>£0.55/mi</strong> plus <strong>£33/hr travel time</strong>.
             Accommodation is added only when the site is more than 1.5 hours from Newbury (3-hour return trip).
           </p>
           <ul class="es-bullets">
@@ -306,7 +306,7 @@
             <p class="pricing-grid__subtitle">Transparent access costs</p>
           </div>
           <p class="pricing-grid__price">
-            <span class="pricing-grid__price-value">£0.45/mi + £33/hr</span>
+            <span class="pricing-grid__price-value">£0.55/mi + £33/hr</span>
             <span class="pricing-grid__price-note">Travel time billed from Newbury</span>
           </p>
           <ul class="pricing-grid__features">
@@ -387,7 +387,7 @@
         <li>We confirm scope, deliverables, travel, and any add-ons in writing.</li>
         <li>You approve and we lock in dates with clear reporting milestones.</li>
       </ol>
-      <p>No VAT to add. Travel is billed from Newbury at £0.45/mile plus £33/hr travel time, with accommodation added for sites over 1.5 hours away, all agreed upfront.</p>
+      <p>No VAT to add. Travel is billed from Newbury at £0.55/mile plus £33/hr travel time, with accommodation added for sites over 1.5 hours away, all agreed upfront.</p>
     </div>
   </section>
 

--- a/protected-species/bats/index.html
+++ b/protected-species/bats/index.html
@@ -128,8 +128,8 @@
     </div>
     <div class="support-coverage">
       <div class="support-coverage__content">
-        <p class="section-lead">Our bat survey team mobilises from Newbury with travel charged transparently from base at £0.45 per mile plus £33 per hour for travel time. We routinely support sites across Berkshire, Oxfordshire, Wiltshire, Hampshire, and adjoining counties with allowances agreed in advance for longer journeys.</p>
-        <div class="coverage-note">Travel is billed from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
+        <p class="section-lead">Our bat survey team mobilises from Newbury with travel charged transparently from base at £0.55 per mile plus £33 per hour for travel time. We routinely support sites across Berkshire, Oxfordshire, Wiltshire, Hampshire, and adjoining counties with allowances agreed in advance for longer journeys.</p>
+        <div class="coverage-note">Travel is billed from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
         <p>Talk to us about phased developments, multi-night programmes, or rapid mobilisation around weather windows—we will build a timetable that keeps your evidence gathering compliant.</p>
       </div>
       <div
@@ -233,7 +233,7 @@
           </tr>
         </tbody>
       </table>
-      <div class="support-pricing__note">Travel is charged from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
+      <div class="support-pricing__note">Travel is charged from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
     </div>
     <details class="pricing-table" id="bat-pricing-comparison">
       <summary class="pricing-table__summary">View detailed package comparison</summary>
@@ -352,7 +352,7 @@
                     <li>Travel planning with accommodation coordination (client may arrange stays for sites &gt;1.5 hours from Newbury)</li>
                   </ul>
                 </td>
-                <td class="pricing-table__price-cell"><strong>+ £0.45/mi travel + £33/hr travel time; overnight stays at cost, with accommodation arranged by client for sites &gt;1.5 hours from Newbury</strong></td>
+                <td class="pricing-table__price-cell"><strong>+ £0.55/mi travel + £33/hr travel time; overnight stays at cost, with accommodation arranged by client for sites &gt;1.5 hours from Newbury</strong></td>
               </tr>
             </tbody>
           </table>

--- a/protected-species/gcn/index.html
+++ b/protected-species/gcn/index.html
@@ -129,8 +129,8 @@
     </div>
     <div class="support-coverage">
       <div class="support-coverage__content">
-        <p class="section-lead">Teams mobilise from Newbury with travel billed from base at £0.45 per mile plus £33 per hour for travel time. We routinely deliver programmes across Berkshire, Oxfordshire, Wiltshire, Hampshire, and neighbouring counties with transparent allowances agreed in advance for longer journeys.</p>
-        <div class="coverage-note">Travel is charged from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
+        <p class="section-lead">Teams mobilise from Newbury with travel billed from base at £0.55 per mile plus £33 per hour for travel time. We routinely deliver programmes across Berkshire, Oxfordshire, Wiltshire, Hampshire, and neighbouring counties with transparent allowances agreed in advance for longer journeys.</p>
+        <div class="coverage-note">Travel is charged from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
         <p>We regularly support multi-pond networks, DLL commitments, and mitigation monitoring—ask about staging survey nights to align with your licenced ecologist’s availability.</p>
       </div>
       <div
@@ -202,12 +202,12 @@
           </tr>
           <tr>
             <th scope="row">Programme travel &amp; overnights</th>
-            <td>Travel is charged from Newbury at £0.45 per mile plus £33 per hour for travel time. Overnight stays are passed through at cost, and for sites more than 1.5 hours away we may request that clients organise accommodation.</td>
-            <td>£0.45/mi + £33/hr travel time; overnight stays at cost</td>
+            <td>Travel is charged from Newbury at £0.55 per mile plus £33 per hour for travel time. Overnight stays are passed through at cost, and for sites more than 1.5 hours away we may request that clients organise accommodation.</td>
+            <td>£0.55/mi + £33/hr travel time; overnight stays at cost</td>
           </tr>
         </tbody>
       </table>
-      <div class="support-pricing__note">Travel is charged from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
+      <div class="support-pricing__note">Travel is charged from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
     </div>
     <details class="pricing-table" id="gcn-pricing-comparison">
       <summary class="pricing-table__summary">View detailed package comparison</summary>
@@ -262,7 +262,7 @@
               </tr>
               <tr>
                 <th scope="row">Programme travel &amp; overnights</th>
-                <td>Travel billed from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost and client-organised accommodation for sites &gt;1.5 hours away.</td>
+                <td>Travel billed from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost and client-organised accommodation for sites &gt;1.5 hours away.</td>
                 <td>
                   <ul class="pricing-table__list">
                     <li>Mileage plan with approval trail</li>
@@ -270,7 +270,7 @@
                     <li>Post-programme cost summary for invoicing</li>
                   </ul>
                 </td>
-                <td class="pricing-table__price-cell"><strong>£0.45/mi + £33/hr travel time; overnight at cost with accommodation organised by client for sites &gt;1.5 hours from Newbury</strong></td>
+                <td class="pricing-table__price-cell"><strong>£0.55/mi + £33/hr travel time; overnight at cost with accommodation organised by client for sites &gt;1.5 hours from Newbury</strong></td>
               </tr>
             </tbody>
           </table>

--- a/protected-species/index.html
+++ b/protected-species/index.html
@@ -126,7 +126,7 @@
     </div>
     <div class="support-coverage">
       <div class="support-coverage__content">
-        <p class="section-lead">We mobilise from Newbury with travel charged transparently at £0.45 per mile plus £33 per hour for travel time, and schedule further afield assignments with pre-agreed allowances.</p>
+        <p class="section-lead">We mobilise from Newbury with travel charged transparently at £0.55 per mile plus £33 per hour for travel time, and schedule further afield assignments with pre-agreed allowances.</p>
         <div class="coverage-note">Early engagement secures peak-season availability and ensures mitigation pathways are documented ahead of planning deadlines.</div>
         <p>Working alongside ecology leads, planners, and contractors, we sequence surveys around project constraints and coordinate licence submissions with Natural England where required.</p>
       </div>

--- a/protected-species/reptiles/index.html
+++ b/protected-species/reptiles/index.html
@@ -128,8 +128,8 @@
     </div>
     <div class="reptile-coverage">
       <div class="reptile-coverage__content">
-        <p class="section-lead">Teams are based from our Newbury hub with travel billed transparently at £0.45 per mile plus £33 per hour for travel time. We routinely deliver across Berkshire, Oxfordshire, Wiltshire, Hampshire, and neighbouring counties with allowances agreed in advance, including overnight arrangements where required.</p>
-        <div class="coverage-note">Travel is charged from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
+        <p class="section-lead">Teams are based from our Newbury hub with travel billed transparently at £0.55 per mile plus £33 per hour for travel time. We routinely deliver across Berkshire, Oxfordshire, Wiltshire, Hampshire, and neighbouring counties with allowances agreed in advance, including overnight arrangements where required.</p>
+        <div class="coverage-note">Travel is charged from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation.</div>
         <p>Talk to us about phased developments or multi-site programmes—we will build a timetable that keeps your fieldwork efficient and compliant.</p>
       </div>
       <div
@@ -170,7 +170,7 @@
   <section class="section container" id="pricing" aria-labelledby="pricing-heading">
     <div class="section-header">
       <h2 id="pricing-heading">Guide pricing with transparent travel</h2>
-      <p class="section-lead">Every proposal is tailored to your site. Guide figures below follow the 2026 rate card: reptile fieldwork at £33/hr with travel billed from Newbury at £0.45 per mile plus £33 per hour for travel time.</p>
+      <p class="section-lead">Every proposal is tailored to your site. Guide figures below follow the 2026 rate card: reptile fieldwork at £33/hr with travel billed from Newbury at £0.55 per mile plus £33 per hour for travel time.</p>
     </div>
     <div class="reptile-pricing">
       <table>
@@ -205,7 +205,7 @@
           </tr>
         </tbody>
       </table>
-      <div class="reptile-pricing__note">Travel is charged from Newbury at £0.45 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation. Ask about multi-site or programme rates for extended schedules.</div>
+      <div class="reptile-pricing__note">Travel is charged from Newbury at £0.55 per mile plus £33 per hour for travel time, with overnight stays passed through at cost. For sites more than 1.5 hours from Newbury we may request that clients organise accommodation. Ask about multi-site or programme rates for extended schedules.</div>
     </div>
     <details class="pricing-table" id="reptile-pricing-comparison">
       <summary class="pricing-table__summary">View detailed package comparison</summary>


### PR DESCRIPTION
### Motivation
- Align the public website pricing with the new mileage rate by updating the per-mile charge from £0.45 to £0.55 across customer-facing pages.

### Description
- Replaced mileage text from `£0.45` to `£0.55` in the pricing and service pages to keep travel costs consistent. 
- Updated the main file `pricing.html` and protected-species pages `protected-species/index.html`, `protected-species/bats/index.html`, `protected-species/gcn/index.html`, and `protected-species/reptiles/index.html`. 
- Preserved the existing `£33/hr` travel-time charge and existing accommodation wording. 
- Changes are textual updates in HTML content only; no JS, CSS, or behavioural code was modified. 

### Testing
- Ran `rg -n '£0\.45' --glob '*.html' --glob '*.md' --glob '*.js' --glob '*.json' --glob '*.txt' .` and confirmed no remaining `£0.45` references (passed). 
- Executed `git diff --check` to validate whitespace and diff checks (passed). 
- Parsed the five updated HTML files with Python's `html.parser` to ensure well-formed HTML after edits (passed). 
- Verified `rg -n '£0\.55' --glob '*.html' .` to confirm the updated references are present on the intended pages (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b97e4c6048325bc4c55fdcbe78615)